### PR TITLE
feat: retry only on specific exit code

### DIFF
--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -1,8 +1,7 @@
 name: CI/CD
 on:
   push:
-    branches:
-      - '**'
+
 jobs:
   # runs on branch pushes only
   ci:

--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -79,6 +79,26 @@ jobs:
           command: node -e "process.exit(1)"
           on_retry_command: node -e "console.log('this is a retry command')"
 
+      - name: retry_on_exit_code (with expected error code)
+        id: retry_on_exit_code
+        uses: ./
+        continue-on-error: true
+        with:
+          timeout_minutes: 1
+          retry_on_exit_code: 2
+          max_attempts: 3
+          command: node -e "process.exit(2)"
+
+      - name: retry_on_exit_code (with unexpected error code)
+        id: retry_on_exit_code
+        uses: ./
+        continue-on-error: true
+        with:
+          timeout_minutes: 1
+          retry_on_exit_code: 2
+          max_attempts: 3
+          command: node -e "process.exit(1)"
+
       - name: on-retry-cmd (on-retry fails)
         id: on-retry-cmd-fails
         uses: ./

--- a/action.yml
+++ b/action.yml
@@ -39,6 +39,9 @@ inputs:
   new_command_on_retry:
     description: Command to run if the first attempt fails. This command will be called on all subsequent attempts.
     required: false
+  retry_on_exit_code:
+    description: Specific exit code to retry on. This will only retry for the given error code and fail immediately other error codes.
+    required: false
 outputs:
   total_attempts:
     description: The final number of attempts made

--- a/dist/index.js
+++ b/dist/index.js
@@ -289,6 +289,7 @@ var WARNING_ON_RETRY = core_1.getInput('warning_on_retry').toLowerCase() === 'tr
 var ON_RETRY_COMMAND = core_1.getInput('on_retry_command');
 var CONTINUE_ON_ERROR = getInputBoolean('continue_on_error');
 var NEW_COMMAND_ON_RETRY = core_1.getInput('new_command_on_retry');
+var RETRY_ON_EXIT_CODE = getInputNumber('retry_on_exit_code', false);
 var OS = process.platform;
 var OUTPUT_TOTAL_ATTEMPTS_KEY = 'total_attempts';
 var OUTPUT_EXIT_CODE_KEY = 'exit_code';
@@ -499,7 +500,8 @@ function runAction() {
                     // error: timeout
                     throw error_2;
                 case 7:
-                    if (!(exit > 0 && RETRY_ON === 'timeout')) return [3 /*break*/, 8];
+                    if (!(((RETRY_ON_EXIT_CODE && RETRY_ON_EXIT_CODE !== exit) || exit > 0) &&
+                        RETRY_ON === 'timeout')) return [3 /*break*/, 8];
                     // error: error
                     throw error_2;
                 case 8: return [4 /*yield*/, runRetryCmd()];

--- a/src/index.ts
+++ b/src/index.ts
@@ -18,6 +18,7 @@ const WARNING_ON_RETRY = getInput('warning_on_retry').toLowerCase() === 'true';
 const ON_RETRY_COMMAND = getInput('on_retry_command');
 const CONTINUE_ON_ERROR = getInputBoolean('continue_on_error');
 const NEW_COMMAND_ON_RETRY = getInput('new_command_on_retry');
+const RETRY_ON_EXIT_CODE = getInputNumber('retry_on_exit_code', false);
 
 const OS = process.platform;
 const OUTPUT_TOTAL_ATTEMPTS_KEY = 'total_attempts';
@@ -187,7 +188,10 @@ async function runAction() {
       } else if (!done && RETRY_ON === 'error') {
         // error: timeout
         throw error;
-      } else if (exit > 0 && RETRY_ON === 'timeout') {
+      } else if (
+        ((RETRY_ON_EXIT_CODE && RETRY_ON_EXIT_CODE !== exit) || exit > 0) &&
+        RETRY_ON === 'timeout'
+      ) {
         // error: error
         throw error;
       } else {


### PR DESCRIPTION
This will add support for retrying only on a specific error code. 

We use (and love) this action in Pleo, but have certain exit codes we'd like to retry for while for other exit codes we don't. 

This PR will add support for passing the `retry_on_exit_code` option to the action and only retry if the exit code is equal to the provided exit code to retry for (if I'm reading the logic correctly - let me know if that's not the case! 👍🏼).  