### PR TITLE
chore: automatic versioning

### DIFF
--- a/.github/workflows/versioning.yml
+++ b/.github/workflows/versioning.yml
@@ -1,0 +1,13 @@
+name: Sync release tags
+
+on:
+  release:
+    types: [published, edited]
+
+jobs:
+  actions-tagger:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: Actions-R-Us/actions-tagger@f411bd910a5ad370d4511517e3eac7ff887c90ea # pin@v2
+        with:
+          publish_latest_tag: true


### PR DESCRIPTION
### Description

This ensures the shorthand tags are updated on every release, i.e. that `v2` always points to the latest `v2.x.y`

### Testing

manually check tags on the next release (I'm using the same workflow on some actions so should be fine as is)