### PR TITLE
Upgrade to node16

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -50,5 +50,5 @@ outputs:
   exit_error:
     description: The final error returned by the command
 runs:
-  using: 'node12'
+  using: 'node16'
   main: 'dist/index.js'


### PR DESCRIPTION
### Description

- Use node 16 cause actions with node 12 are deprecated
> Node.js 12 actions are deprecated. For more information see: https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/. Please update the following actions to use Node.js 16: nick-fields/retry

### Testing

- What tests were added?
  - These can be either ["integration tests"](./workflows/ci_cd.yml) or unit tests
