### PR TITLE
Fix link to documentation about `shell`

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.md
+++ b/.github/ISSUE_TEMPLATE/bug-report.md
@@ -16,4 +16,4 @@ A clear and concise description of what you expected to happen.
 If applicable, add screenshots to help explain your problem.
 
 **Logs**
-Enable [debug logging](https://docs.github.com/en/free-pro-team@latest/actions/managing-workflow-runs/enabling-debug-logging#enabling-step-debug-logging) then attach the [raw logs](https://docs.github.com/en/free-pro-team@latest/actions/managing-workflow-runs/using-workflow-run-logs#downloading-logs) (specifically the raw output of this action).
+Enable [debug logging](https://docs.github.com/en/actions/monitoring-and-troubleshooting-workflows/enabling-debug-logging#enabling-step-debug-logging) then attach the [raw logs](https://docs.github.com/en/actions/monitoring-and-troubleshooting-workflows/using-workflow-run-logs#downloading-logs) (specifically the raw output of this action).

--- a/README.md
+++ b/README.md
@@ -156,7 +156,7 @@ with:
 ```yaml
 - uses: nick-fields/retry@v2
   id: retry
-  # see https://docs.github.com/en/free-pro-team@latest/actions/reference/workflow-syntax-for-github-actions#jobsjob_idcontinue-on-error
+  # see https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idcontinue-on-error
   continue-on-error: true
   with:
     timeout_seconds: 15

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Retries an Action step on failure or timeout. This is currently intended to repl
 
 ### `shell`
 
-**Optional** Shell to use to execute `command`. Defaults to `powershell` on Windows, `bash` otherwise. Supports bash, python, pwsh, sh, cmd, and powershell per [docs](https://docs.github.com/en/free-pro-team@latest/actions/reference/workflow-syntax-for-github-actions#using-a-specific-shell)
+**Optional** Shell to use to execute `command`. Defaults to `powershell` on Windows, `bash` otherwise. Supports bash, python, pwsh, sh, cmd, and powershell per [docs](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstepsshell)
 
 ### `polling_interval_seconds`
 

--- a/dist/index.js
+++ b/dist/index.js
@@ -971,7 +971,7 @@ function getExecutable(inputs) {
             break;
         }
         default: {
-            throw new Error("Shell ".concat(inputs.shell, " not supported.  See https://docs.github.com/en/free-pro-team@latest/actions/reference/workflow-syntax-for-github-actions#using-a-specific-shell for supported shells"));
+            throw new Error("Shell ".concat(inputs.shell, " not supported.  See https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstepsshell for supported shells"));
         }
     }
     return executable;

--- a/src/index.ts
+++ b/src/index.ts
@@ -44,7 +44,7 @@ function getExecutable(inputs: Inputs): string {
     }
     default: {
       throw new Error(
-        `Shell ${inputs.shell} not supported.  See https://docs.github.com/en/free-pro-team@latest/actions/reference/workflow-syntax-for-github-actions#using-a-specific-shell for supported shells`
+        `Shell ${inputs.shell} not supported.  See https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstepsshell for supported shells`
       );
     }
   }


### PR DESCRIPTION
### Description

Fix the link to documentation about `shell`.
The current link does not point to the correct position in the documentation.

### Testing

Not needed.
