### PR TITLE
fix: Retry on timeout

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -1026,12 +1026,12 @@ function runCmd(attempt, inputs) {
                     child.on('exit', function (code, signal) {
                         (0, core_1.debug)("Code: ".concat(code));
                         (0, core_1.debug)("Signal: ".concat(signal));
-                        if (code && code > 0) {
-                            exit = code;
-                        }
                         // timeouts are killed manually
                         if (signal === 'SIGTERM') {
                             return;
+                        }
+                        if (code && code > 0) {
+                            exit = code;
                         }
                         done = true;
                     });

--- a/dist/index.js
+++ b/dist/index.js
@@ -1005,7 +1005,7 @@ function runRetryCmd(inputs) {
 function runCmd(attempt, inputs) {
     var _a, _b;
     return __awaiter(this, void 0, void 0, function () {
-        var end_time, executable, child;
+        var end_time, executable, timeout, child;
         return __generator(this, function (_c) {
             switch (_c.label) {
                 case 0:
@@ -1013,6 +1013,7 @@ function runCmd(attempt, inputs) {
                     executable = getExecutable(inputs);
                     exit = 0;
                     done = false;
+                    timeout = false;
                     (0, core_1.debug)("Running command ".concat(inputs.command, " on ").concat(OS, " using shell ").concat(executable));
                     child = attempt > 1 && inputs.new_command_on_retry
                         ? (0, child_process_1.spawn)(inputs.new_command_on_retry, { shell: executable })
@@ -1030,6 +1031,10 @@ function runCmd(attempt, inputs) {
                         if (signal === 'SIGTERM') {
                             return;
                         }
+                        // On Windows signal is null.
+                        if (timeout) {
+                            return;
+                        }
                         if (code && code > 0) {
                             exit = code;
                         }
@@ -1045,6 +1050,7 @@ function runCmd(attempt, inputs) {
                     _c.label = 4;
                 case 4:
                     if (!(!done && child.pid)) return [3 /*break*/, 6];
+                    timeout = true;
                     (0, tree_kill_1.default)(child.pid);
                     return [4 /*yield*/, (0, util_1.retryWait)(milliseconds_1.default.seconds(inputs.retry_wait_seconds))];
                 case 5:

--- a/src/index.ts
+++ b/src/index.ts
@@ -71,6 +71,7 @@ async function runCmd(attempt: number, inputs: Inputs) {
 
   exit = 0;
   done = false;
+  let timeout = false;
 
   debug(`Running command ${inputs.command} on ${OS} using shell ${executable}`);
   const child =
@@ -94,6 +95,11 @@ async function runCmd(attempt: number, inputs: Inputs) {
       return;
     }
 
+    // On Windows signal is null.
+    if (timeout) {
+      return;
+    }
+
     if (code && code > 0) {
       exit = code;
     }
@@ -106,6 +112,7 @@ async function runCmd(attempt: number, inputs: Inputs) {
   } while (Date.now() < end_time && !done);
 
   if (!done && child.pid) {
+    timeout = true;
     kill(child.pid);
     await retryWait(ms.seconds(inputs.retry_wait_seconds));
     throw new Error(`Timeout of ${getTimeout(inputs)}ms hit`);

--- a/src/index.ts
+++ b/src/index.ts
@@ -88,13 +88,16 @@ async function runCmd(attempt: number, inputs: Inputs) {
   child.on('exit', (code, signal) => {
     debug(`Code: ${code}`);
     debug(`Signal: ${signal}`);
-    if (code && code > 0) {
-      exit = code;
-    }
+
     // timeouts are killed manually
     if (signal === 'SIGTERM') {
       return;
     }
+
+    if (code && code > 0) {
+      exit = code;
+    }
+
     done = true;
   });
 


### PR DESCRIPTION
_Replace the bullet points below with your answers_

### Description

- Non-success exit codes are ignored for commands that have timed out and killed by this script, as processes that haven't terminated gracefully usually return a non-zero value.
- A variable is used to track timeouts instead of the signal kind (SIGTERM) as Windows doesn't use signals for process termination.

Should fix #44.

### Testing

- What tests were added?
  - These can be either ["integration tests"](./workflows/ci_cd.yml) or unit tests
