### PR TITLE
Run workflow on PR into default branch only

### DIFF
--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -1,12 +1,13 @@
 name: CI/CD
 on:
-  push:
+  # only on PRs into default branch
+  pull_request:
+    branches:
+      - master
 
 jobs:
-  # runs on branch pushes only
   ci_unit:
     name: Run Unit Tests
-    if: startsWith(github.ref, 'refs/heads')
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -26,7 +27,6 @@ jobs:
 
   ci_integration:
     name: Run Integration Tests
-    if: startsWith(github.ref, 'refs/heads')
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -137,7 +137,6 @@ jobs:
 
   ci_integration_envvar:
     name: Run Integration Env Var Tests
-    if: startsWith(github.ref, 'refs/heads')
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -159,7 +158,6 @@ jobs:
 
   ci_integration_large_output:
     name: Run Integration Large Output Tests
-    if: startsWith(github.ref, 'refs/heads')
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -191,7 +189,6 @@ jobs:
 
   ci_integration_retry_on_exit_code:
     name: Run Integration retry_on_exit_code Tests
-    if: startsWith(github.ref, 'refs/heads')
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -240,7 +237,6 @@ jobs:
 
   ci_integration_continue_on_error:
     name: Run Integration continue_on_error Tests
-    if: startsWith(github.ref, 'refs/heads')
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -288,7 +284,6 @@ jobs:
 
   ci_integration_retry_wait_seconds:
     name: Run Integration Tests (retry_wait_seconds)
-    if: startsWith(github.ref, 'refs/heads')
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -325,7 +320,6 @@ jobs:
 
   ci_integration_on_retry_cmd:
     name: Run Integration Tests (on_retry_command)
-    if: startsWith(github.ref, 'refs/heads')
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -369,7 +363,6 @@ jobs:
   # timeout tests take longer to run so run in parallel
   ci_integration_timeout_seconds:
     name: Run Integration Timeout Tests (seconds)
-    if: startsWith(github.ref, 'refs/heads')
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -400,7 +393,6 @@ jobs:
 
   ci_integration_timeout_retry_on_timeout:
     name: Run Integration Timeout Tests (retry_on timeout)
-    if: startsWith(github.ref, 'refs/heads')
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -432,7 +424,6 @@ jobs:
 
   ci_integration_timeout_retry_on_error:
     name: Run Integration Timeout Tests (retry_on error)
-    if: startsWith(github.ref, 'refs/heads')
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -468,7 +459,6 @@ jobs:
 
   ci_integration_timeout_minutes:
     name: Run Integration Timeout Tests (minutes)
-    if: startsWith(github.ref, 'refs/heads')
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -499,7 +489,6 @@ jobs:
 
   ci_windows:
     name: Run Windows Tests
-    if: startsWith(github.ref, 'refs/heads')
     runs-on: windows-latest
     steps:
       - name: Checkout
@@ -571,7 +560,7 @@ jobs:
     steps:
       - run: echo "If this is hit, all tests successfully passed"
 
-  # runs on push to master only
+  # runs on merge to master only
   cd:
     name: Publish Action
     needs: [ci_all_tests_passed]


### PR DESCRIPTION
Not sure why I had this setup for push events only, it prevents workflows from running on contribution PRs from forked repos