### PR TITLE
Update action to node20

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -50,5 +50,5 @@ outputs:
   exit_error:
     description: The final error returned by the command
 runs:
-  using: 'node16'
+  using: 'node20'
   main: 'dist/index.js'


### PR DESCRIPTION
### Description

- node16 -> node20 in action.yml
- because we're getting a warning in our workflows that use this

<img width="1435" alt="image" src="https://github.com/nick-fields/retry/assets/15040698/d1ff9857-84ad-4ec0-883b-06151a8a20e8">


### Testing

- none - assuming existing testing covers this
