### PR TITLE
fix: group log lines for each attempt

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -130,6 +130,7 @@ async function runAction(inputs: Inputs) {
   await validateInputs(inputs);
 
   for (let attempt = 1; attempt <= inputs.max_attempts; attempt++) {
+    info(`::group::Attempt ${attempt}`);
     try {
       // just keep overwriting attempts output
       setOutput(OUTPUT_TOTAL_ATTEMPTS_KEY, attempt);
@@ -156,6 +157,8 @@ async function runAction(inputs: Inputs) {
           info(`Attempt ${attempt} failed. Reason: ${error.message}`);
         }
       }
+    } finally {
+      info(`::endgroup::`);
     }
   }
 }


### PR DESCRIPTION
### Description

- The change allows to group logs from each attempt in the github UI so it is easier for users to check the logs.

### Testing

- What tests were added?
  - Could not be tested directly from test cases as the change is reflected only in GitHub UI. 
  
  Here is a sample on how it looks in the logs.
  
  
![image](https://github.com/user-attachments/assets/46228f93-3f63-4412-9075-3505b53b0205)

