### PR TITLE
Bump action versions, fix tag step in release, regen js

### DIFF
--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -584,6 +584,8 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Tag
+        # only bump v# (e.g., v3) tag if semantic release action publishes any new version
+        if: ${{ steps.semantic.outputs.new_release_major_version != '' }}
         run: git tag -f v${MAJOR_VERSION} && git push -f origin v${MAJOR_VERSION}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -48,7 +48,7 @@ jobs:
           timeout_minutes: 1
           max_attempts: 2
           command: npm -v
-      - uses: nick-fields/assert-action@v1
+      - uses: nick-fields/assert-action@v2
         with:
           expected: true
           actual: ${{ steps.happy_path.outputs.total_attempts == '1' && steps.happy_path.outputs.exit_code == '0' }}
@@ -67,11 +67,11 @@ jobs:
           timeout_minutes: 1
           max_attempts: 2
           command: node -e "process.exit(1)"
-      - uses: nick-fields/assert-action@v1
+      - uses: nick-fields/assert-action@v2
         with:
           expected: 2
           actual: ${{ steps.sad_path_error.outputs.total_attempts }}
-      - uses: nick-fields/assert-action@v1
+      - uses: nick-fields/assert-action@v2
         with:
           expected: failure
           actual: ${{ steps.sad_path_error.outcome }}
@@ -85,15 +85,15 @@ jobs:
           max_attempts: 3
           retry_on: timeout
           command: node -e "process.exit(2)"
-      - uses: nick-fields/assert-action@v1
+      - uses: nick-fields/assert-action@v2
         with:
           expected: 1
           actual: ${{ steps.retry_on_timeout_fail.outputs.total_attempts }}
-      - uses: nick-fields/assert-action@v1
+      - uses: nick-fields/assert-action@v2
         with:
           expected: failure
           actual: ${{ steps.retry_on_timeout_fail.outcome }}
-      - uses: nick-fields/assert-action@v1
+      - uses: nick-fields/assert-action@v2
         with:
           expected: 2
           actual: ${{ steps.retry_on_timeout_fail.outputs.exit_code }}
@@ -107,15 +107,15 @@ jobs:
           max_attempts: 2
           retry_on: error
           command: node -e "process.exit(2)"
-      - uses: nick-fields/assert-action@v1
+      - uses: nick-fields/assert-action@v2
         with:
           expected: 2
           actual: ${{ steps.retry_on_error.outputs.total_attempts }}
-      - uses: nick-fields/assert-action@v1
+      - uses: nick-fields/assert-action@v2
         with:
           expected: failure
           actual: ${{ steps.retry_on_error.outcome }}
-      - uses: nick-fields/assert-action@v1
+      - uses: nick-fields/assert-action@v2
         with:
           expected: 2
           actual: ${{ steps.retry_on_error.outputs.exit_code }}
@@ -129,11 +129,11 @@ jobs:
           max_attempts: 2
           shell: cmd
           command: 'dir'
-      - uses: nick-fields/assert-action@v1
+      - uses: nick-fields/assert-action@v2
         with:
           expected: 2
           actual: ${{ steps.wrong_shell.outputs.total_attempts }}
-      - uses: nick-fields/assert-action@v1
+      - uses: nick-fields/assert-action@v2
         with:
           expected: failure
           actual: ${{ steps.wrong_shell.outcome }}
@@ -180,12 +180,12 @@ jobs:
           timeout_minutes: 5
           command: 'make -C ./test-data/large-output bytes-102400'
       - name: Assert test had expected result
-        uses: nick-fields/assert-action@v1
+        uses: nick-fields/assert-action@v2
         with:
           expected: failure
           actual: ${{ steps.large-output.outcome }}
       - name: Assert exit code is expected
-        uses: nick-fields/assert-action@v1
+        uses: nick-fields/assert-action@v2
         with:
           expected: 2
           actual: ${{ steps.large-output.outputs.exit_code }}
@@ -211,11 +211,11 @@ jobs:
           retry_on_exit_code: 2
           max_attempts: 3
           command: node -e "process.exit(2)"
-      - uses: nick-fields/assert-action@v1
+      - uses: nick-fields/assert-action@v2
         with:
           expected: failure
           actual: ${{ steps.retry_on_exit_code_expected.outcome }}
-      - uses: nick-fields/assert-action@v1
+      - uses: nick-fields/assert-action@v2
         with:
           expected: 3
           actual: ${{ steps.retry_on_exit_code_expected.outputs.total_attempts }}
@@ -229,11 +229,11 @@ jobs:
           retry_on_exit_code: 2
           max_attempts: 3
           command: node -e "process.exit(1)"
-      - uses: nick-fields/assert-action@v1
+      - uses: nick-fields/assert-action@v2
         with:
           expected: failure
           actual: ${{ steps.retry_on_exit_code_unexpected.outcome }}
-      - uses: nick-fields/assert-action@v1
+      - uses: nick-fields/assert-action@v2
         with:
           expected: 1
           actual: ${{ steps.retry_on_exit_code_unexpected.outputs.total_attempts }}
@@ -265,22 +265,22 @@ jobs:
           timeout_minutes: 1
           continue_on_error: true
       - name: Verify continue_on_error returns correct exit code on success
-        uses: nick-fields/assert-action@v1
+        uses: nick-fields/assert-action@v2
         with:
           expected: 0
           actual: ${{ steps.happy_path_continue_on_error.outputs.exit_code }}
       - name: Verify continue_on_error exits with correct outcome on success
-        uses: nick-fields/assert-action@v1
+        uses: nick-fields/assert-action@v2
         with:
           expected: success
           actual: ${{ steps.happy_path_continue_on_error.outcome }}
       - name: Verify continue_on_error returns correct exit code on error
-        uses: nick-fields/assert-action@v1
+        uses: nick-fields/assert-action@v2
         with:
           expected: 33
           actual: ${{ steps.sad_path_continue_on_error.outputs.exit_code }}
       - name: Verify continue_on_error exits with successful outcome when an error occurs
-        uses: nick-fields/assert-action@v1
+        uses: nick-fields/assert-action@v2
         with:
           expected: success
           actual: ${{ steps.sad_path_continue_on_error.outcome }}
@@ -307,15 +307,15 @@ jobs:
           max_attempts: 3
           retry_wait_seconds: 15
           command: npm install this-isnt-a-real-package-name-zzz
-      - uses: nick-fields/assert-action@v1
+      - uses: nick-fields/assert-action@v2
         with:
           expected: 3
           actual: ${{ steps.sad_path_wait_sec.outputs.total_attempts }}
-      - uses: nick-fields/assert-action@v1
+      - uses: nick-fields/assert-action@v2
         with:
           expected: failure
           actual: ${{ steps.sad_path_wait_sec.outcome }}
-      - uses: nick-fields/assert-action@v1
+      - uses: nick-fields/assert-action@v2
         with:
           expected: 'Final attempt failed'
           actual: ${{ steps.sad_path_wait_sec.outputs.exit_error }}
@@ -385,11 +385,11 @@ jobs:
           timeout_seconds: 15
           max_attempts: 2
           command: node -e "(async()=>await new Promise(r => setTimeout(r, 120000)))()"
-      - uses: nick-fields/assert-action@v1
+      - uses: nick-fields/assert-action@v2
         with:
           expected: 2
           actual: ${{ steps.sad_path_timeout.outputs.total_attempts }}
-      - uses: nick-fields/assert-action@v1
+      - uses: nick-fields/assert-action@v2
         with:
           expected: failure
           actual: ${{ steps.sad_path_timeout.outcome }}
@@ -416,11 +416,11 @@ jobs:
           max_attempts: 2
           retry_on: timeout
           command: node -e "(async()=>await new Promise(r => setTimeout(r, 120000)))()"
-      - uses: nick-fields/assert-action@v1
+      - uses: nick-fields/assert-action@v2
         with:
           expected: 2
           actual: ${{ steps.retry_on_timeout.outputs.total_attempts }}
-      - uses: nick-fields/assert-action@v1
+      - uses: nick-fields/assert-action@v2
         with:
           expected: failure
           actual: ${{ steps.retry_on_timeout.outcome }}
@@ -447,15 +447,15 @@ jobs:
           max_attempts: 2
           retry_on: error
           command: node -e "(async()=>await new Promise(r => setTimeout(r, 120000)))()"
-      - uses: nick-fields/assert-action@v1
+      - uses: nick-fields/assert-action@v2
         with:
           expected: 1
           actual: ${{ steps.retry_on_error_fail.outputs.total_attempts }}
-      - uses: nick-fields/assert-action@v1
+      - uses: nick-fields/assert-action@v2
         with:
           expected: failure
           actual: ${{ steps.retry_on_error_fail.outcome }}
-      - uses: nick-fields/assert-action@v1
+      - uses: nick-fields/assert-action@v2
         with:
           expected: 1
           actual: ${{ steps.retry_on_error_fail.outputs.exit_code }}
@@ -481,11 +481,11 @@ jobs:
           timeout_minutes: 1
           max_attempts: 2
           command: node -e "(async()=>await new Promise(r => setTimeout(r, 120000)))()"
-      - uses: nick-fields/assert-action@v1
+      - uses: nick-fields/assert-action@v2
         with:
           expected: 2
           actual: ${{ steps.sad_path_timeout_minutes.outputs.total_attempts }}
-      - uses: nick-fields/assert-action@v1
+      - uses: nick-fields/assert-action@v2
         with:
           expected: failure
           actual: ${{ steps.sad_path_timeout_minutes.outcome }}

--- a/dist/index.js
+++ b/dist/index.js
@@ -25040,17 +25040,18 @@ function runAction(inputs) {
                     attempt = 1;
                     _a.label = 2;
                 case 2:
-                    if (!(attempt <= inputs.max_attempts)) return [3 /*break*/, 13];
+                    if (!(attempt <= inputs.max_attempts)) return [3 /*break*/, 14];
+                    (0, core_1.info)("::group::Attempt ".concat(attempt));
                     _a.label = 3;
                 case 3:
-                    _a.trys.push([3, 5, , 12]);
+                    _a.trys.push([3, 5, 12, 13]);
                     // just keep overwriting attempts output
                     (0, core_1.setOutput)(OUTPUT_TOTAL_ATTEMPTS_KEY, attempt);
                     return [4 /*yield*/, runCmd(attempt, inputs)];
                 case 4:
                     _a.sent();
                     (0, core_1.info)("Command completed after ".concat(attempt, " attempt(s)."));
-                    return [3 /*break*/, 13];
+                    return [3 /*break*/, 14];
                 case 5:
                     error_2 = _a.sent();
                     if (!(attempt === inputs.max_attempts)) return [3 /*break*/, 6];
@@ -25076,11 +25077,14 @@ function runAction(inputs) {
                         (0, core_1.info)("Attempt ".concat(attempt, " failed. Reason: ").concat(error_2.message));
                     }
                     _a.label = 11;
-                case 11: return [3 /*break*/, 12];
+                case 11: return [3 /*break*/, 13];
                 case 12:
+                    (0, core_1.info)("::endgroup::");
+                    return [7 /*endfinally*/];
+                case 13:
                     attempt++;
                     return [3 /*break*/, 2];
-                case 13: return [2 /*return*/];
+                case 14: return [2 /*return*/];
             }
         });
     });


### PR DESCRIPTION
### Description

- Bumps nick-fields/assert-action@v1 action to v2 (cc @xavier2k6)
- Only attempt to move the latest major tag (e.g., v3) if any release was published
- Regenerate js so that previous #146 is picked up (cc @raja-anbazhagan)
  - The generation is done automatically via pre-commit hook, but skipped when contributions are made through GH UI.  I'll look into just auto-generating and committing the change in CI